### PR TITLE
Changed how the api is initialized and how API handler is passed on.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# Quick Note
+
+I found this quick example [ynsrc/python-simple-rest-api](https://github.com/ynsrc/python-simple-rest-api) of a simple Python API while looking for quick reference to cobble together a quick API for simple a RPI project I am working on (didn't need or want the overhead of FastAPI or equivalent for this simple home project - litterally to set off an animal trap I wanted and API endpoint). I though your little example was spot on for my purposes but there was one thing that I felt could be handled a little bit different and I feel like makes it a little easier extendable and I thought it would be a bit cleaner to remove the ApiRequestHandler definition from inside __main__ and especially with the global api reference.
+
+Basically, all I did was add a method call to the API class that get passed to the HTTPServer instead of the ApiRequestHandler. Internally to the HTTPServer it will "init" the RequestHandlerClass but in this case will just call the API instance. The callable method will then instantiate the ApiRequestHandler passing a reference to the API instance to the ApiRequestHandler without the need for the global in the ApiRequestHandler.
+
+In the ApiRequestHandler all I had to do was initialize the super class passing the same arguments needed for the BaseHTTPRequestHandler while allowing it to pass the api object. Then the API callable returns that ApiRequestHandler object that carries with reference to itself.
+
+
 # Simple REST API with pure Python
 
 This is an example REST API project.

--- a/server.py
+++ b/server.py
@@ -6,8 +6,8 @@ PORT = 5000
 
 class ApiRequestHandler(BaseHTTPRequestHandler):
 
-    def __init__(self, request, client_address, ref_self, api):
-        super().__init__(request, client_address, ref_self)
+    def __init__(self, request, client_address, ref_req, api):
+        super().__init__(request, client_address, ref_req)
         self.api = api
 
     def call_api(self, method, path, args):

--- a/server.py
+++ b/server.py
@@ -148,8 +148,6 @@ def delete(args):
 
 if __name__ == "__main__":
 
-
-
     httpd = HTTPServer(('', PORT), api)
     print(f"Application started at http://127.0.0.1:{PORT}/")
     httpd.serve_forever()

--- a/server.py
+++ b/server.py
@@ -4,10 +4,58 @@ from urllib.parse import urlparse, parse_qs
 
 PORT = 5000
 
+class ApiRequestHandler(BaseHTTPRequestHandler):
+
+    def __init__(self, request, client_address, ref_self, api):
+        super().__init__(request, client_address, ref_self)
+        self.api = api
+
+    def call_api(self, method, path, args):
+        if path in api.routing[method]:
+            try:
+                result = api.routing[method][path](args)
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(json.dumps(result, indent=4).encode())
+            except Exception as e:
+                self.send_response(500, "Server Error")
+                self.end_headers()
+                self.wfile.write(json.dumps({ "error": e.args }, indent=4).encode())
+        else:
+            self.send_response(404, "Not Found")
+            self.end_headers()
+            self.wfile.write(json.dumps({"error": "not found"}, indent=4).encode())
+
+    def do_GET(self):
+        parsed_url = urlparse(self.path)
+        path = parsed_url.path
+        args = parse_qs(parsed_url.query)
+
+        for k in args.keys():
+            if len(args[k]) == 1:
+                args[k] = args[k][0]
+
+        self.call_api("GET", path, args)
+
+    def do_POST(self):
+        parsed_url = urlparse(self.path)
+        path = parsed_url.path
+        if self.headers.get("content-type") != "application/json":
+            self.send_response(400)
+            self.end_headers()
+            self.wfile.write(json.dumps({
+                "error": "posted data must be in json format"
+            }, indent=4).encode())
+        else:
+            data_len = int(self.headers.get("content-length"))
+            data = self.rfile.read(data_len).decode()
+            self.call_api("POST", path, json.loads(data))
+
+
 class API():
     def __init__(self):
         self.routing = { "GET": { }, "POST": { } }
-    
+
     def get(self, path):
         def wrapper(fn):
             self.routing["GET"][path] = fn
@@ -17,6 +65,11 @@ class API():
         def wrapper(fn):
             self.routing["POST"][path] = fn
         return wrapper
+
+    def __call__(self, request, client_address, ref_request):
+        api_handler = ApiRequestHandler(request, client_address, ref_request, api=self)
+        return api_handler
+
 
 api = API()
 
@@ -30,7 +83,7 @@ example_data = {
 
 @api.get("/")
 def index(_):
-    return { 
+    return {
         "name": "Python REST API Example",
         "summary": "This is simple REST API architecture with pure Python",
         "actions": [ "add", "delete", "list", "search" ],
@@ -86,7 +139,7 @@ def delete(args):
                 example_data["items"].remove(item)
                 item_deleted = True
                 break
-        
+
         if item_deleted:
             return { "deleted": id }
         else:
@@ -94,52 +147,10 @@ def delete(args):
 
 
 if __name__ == "__main__":
-    class ApiRequestHandler(BaseHTTPRequestHandler):
-        global api
-        
-        def call_api(self, method, path, args):
-            if path in api.routing[method]:
-                try:
-                    result = api.routing[method][path](args)
-                    self.send_response(200)
-                    self.end_headers()
-                    self.wfile.write(json.dumps(result, indent=4).encode())
-                except Exception as e:
-                    self.send_response(500, "Server Error")
-                    self.end_headers()
-                    self.wfile.write(json.dumps({ "error": e.args }, indent=4).encode())
-            else:
-                self.send_response(404, "Not Found")
-                self.end_headers()
-                self.wfile.write(json.dumps({"error": "not found"}, indent=4).encode())
-
-        def do_GET(self):
-            parsed_url = urlparse(self.path)
-            path = parsed_url.path
-            args = parse_qs(parsed_url.query)
-            
-            for k in args.keys():
-                if len(args[k]) == 1:
-                    args[k] = args[k][0]
-            
-            self.call_api("GET", path, args)
-
-        def do_POST(self):
-            parsed_url = urlparse(self.path)
-            path = parsed_url.path
-            if self.headers.get("content-type") != "application/json":
-                self.send_response(400)
-                self.end_headers()
-                self.wfile.write(json.dumps({
-                    "error": "posted data must be in json format"
-                }, indent=4).encode())
-            else:
-                data_len = int(self.headers.get("content-length"))
-                data = self.rfile.read(data_len).decode()
-                self.call_api("POST", path, json.loads(data))
 
 
-    httpd = HTTPServer(('', PORT), ApiRequestHandler)
+
+    httpd = HTTPServer(('', PORT), api)
     print(f"Application started at http://127.0.0.1:{PORT}/")
     httpd.serve_forever()
 

--- a/server.py
+++ b/server.py
@@ -6,9 +6,9 @@ PORT = 5000
 
 class ApiRequestHandler(BaseHTTPRequestHandler):
 
-    def __init__(self, request, client_address, ref_req, api):
+    def __init__(self, request, client_address, ref_req, api_ref):
+        self.api = api_ref
         super().__init__(request, client_address, ref_req)
-        self.api = api
 
     def call_api(self, method, path, args):
         if path in api.routing[method]:
@@ -67,7 +67,7 @@ class API():
         return wrapper
 
     def __call__(self, request, client_address, ref_request):
-        api_handler = ApiRequestHandler(request, client_address, ref_request, api=self)
+        api_handler = ApiRequestHandler(request, client_address, ref_request, api_ref=self)
         return api_handler
 
 


### PR DESCRIPTION
Hey was looking for a quick example of a simple Python API to cobble together real quick for simple RPI project I am working on. I though your little example was spot on for my purposes but there was one thing that I felt could be handled a little bit different and I feel like makes it a little easier extendable and I thought it would be a bit cleaner to remove the ApiRequestHandler definition from inside __main__ and especially with the global api reference.

Basically, all I did was add a method call to the API class that get passed to the HTTPServer instead of the ApiRequestHandler. Internally to the HTTPServer it will "init" the RequestHandlerClass but in this case will just call the API instance. The callable method will then instantiate the ApiRequestHandler passing a reference to the API instance to the ApiRequestHandler without the need for the global in the ApiRequestHandler. 

In the ApiRequestHandler all I had to do was initialize the super class passing the same arguments needed for the BaseHTTPRequestHandler while allowing it to pass the api object. Then the API callable returns that ApiRequestHandler object that carries with reference to itself.